### PR TITLE
Convert Interface Bandwith oids from 32 bit ones to 64 bit

### DIFF
--- a/zbx-templates/zbx-cisco/zbx-cisco-interfaces/zbx-cisco-interfaces.xml
+++ b/zbx-templates/zbx-cisco/zbx-cisco-interfaces/zbx-cisco-interfaces.xml
@@ -411,8 +411,8 @@ ignored by this interface.</description>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>1</multiplier>
-                            <snmp_oid>IF-MIB::ifInOctets.{#SNMPINDEX}</snmp_oid>
-                            <key>ifInOctets[{#SNMPVALUE}]</key>
+                            <snmp_oid>IF-MIB::ifHCInOctets.{#SNMPINDEX}</snmp_oid>
+                            <key>ifHCInOctets[{#SNMPVALUE}]</key>
                             <delay>60</delay>
                             <history>7</history>
                             <trends>365</trends>
@@ -648,8 +648,8 @@ misaligned.</description>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>1</multiplier>
-                            <snmp_oid>IF-MIB::ifOutOctets.{#SNMPINDEX}</snmp_oid>
-                            <key>ifOutOctets[{#SNMPVALUE}]</key>
+                            <snmp_oid>IF-MIB::IfHCOutOctets.{#SNMPINDEX}</snmp_oid>
+                            <key>IfHCOutOctets[{#SNMPVALUE}]</key>
                             <delay>60</delay>
                             <history>7</history>
                             <trends>365</trends>
@@ -897,7 +897,7 @@ which has the meaning as:&#13;
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{ZBX-CISCO-INTERFACES:if.speed[&quot;-d&quot;,&quot;{HOST.HOST}&quot;,&quot;-c&quot;,&quot;{$SNMP_COMMUNITY}&quot;,&quot;-s&quot;,&quot;{#SNMPINDEX}&quot;].last(0)}&gt;0 &amp; ({ZBX-CISCO-INTERFACES:ifInOctets[{#SNMPVALUE}].avg(300)})&gt;({ZBX-CISCO-INTERFACES:if.speed[&quot;-d&quot;,&quot;{HOST.HOST}&quot;,&quot;-c&quot;,&quot;{$SNMP_COMMUNITY}&quot;,&quot;-s&quot;,&quot;{#SNMPINDEX}&quot;].last(0)})*0.8</expression>
+                            <expression>{ZBX-CISCO-INTERFACES:if.speed[&quot;-d&quot;,&quot;{HOST.HOST}&quot;,&quot;-c&quot;,&quot;{$SNMP_COMMUNITY}&quot;,&quot;-s&quot;,&quot;{#SNMPINDEX}&quot;].last(0)}&gt;0 &amp; ({ZBX-CISCO-INTERFACES:ifHCInOctets[{#SNMPVALUE}].avg(300)})&gt;({ZBX-CISCO-INTERFACES:if.speed[&quot;-d&quot;,&quot;{HOST.HOST}&quot;,&quot;-c&quot;,&quot;{$SNMP_COMMUNITY}&quot;,&quot;-s&quot;,&quot;{#SNMPINDEX}&quot;].last(0)})*0.8</expression>
                             <name>Incoming use on interface {#SNMPVALUE} exceed 80% for the last 5 minutes</name>
                             <url/>
                             <status>0</status>
@@ -933,7 +933,7 @@ which has the meaning as:&#13;
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{ZBX-CISCO-INTERFACES:if.speed[&quot;-d&quot;,&quot;{HOST.HOST}&quot;,&quot;-c&quot;,&quot;{$SNMP_COMMUNITY}&quot;,&quot;-s&quot;,&quot;{#SNMPINDEX}&quot;].last(0)}&gt;0 &amp; ({ZBX-CISCO-INTERFACES:ifOutOctets[{#SNMPVALUE}].avg(300)})&gt;({ZBX-CISCO-INTERFACES:if.speed[&quot;-d&quot;,&quot;{HOST.HOST}&quot;,&quot;-c&quot;,&quot;{$SNMP_COMMUNITY}&quot;,&quot;-s&quot;,&quot;{#SNMPINDEX}&quot;].last(0)})*0.8</expression>
+                            <expression>{ZBX-CISCO-INTERFACES:if.speed[&quot;-d&quot;,&quot;{HOST.HOST}&quot;,&quot;-c&quot;,&quot;{$SNMP_COMMUNITY}&quot;,&quot;-s&quot;,&quot;{#SNMPINDEX}&quot;].last(0)}&gt;0 &amp; ({ZBX-CISCO-INTERFACES:IfHCOutOctets[{#SNMPVALUE}].avg(300)})&gt;({ZBX-CISCO-INTERFACES:if.speed[&quot;-d&quot;,&quot;{HOST.HOST}&quot;,&quot;-c&quot;,&quot;{$SNMP_COMMUNITY}&quot;,&quot;-s&quot;,&quot;{#SNMPINDEX}&quot;].last(0)})*0.8</expression>
                             <name>Outgoing use on interface {#SNMPVALUE} exceed 80% for the last 5 minutes</name>
                             <url/>
                             <status>0</status>
@@ -1172,7 +1172,7 @@ which has the meaning as:&#13;
                                     <type>0</type>
                                     <item>
                                         <host>ZBX-CISCO-INTERFACES</host>
-                                        <key>ifInOctets[{#SNMPVALUE}]</key>
+                                        <key>ifHCInOctets[{#SNMPVALUE}]</key>
                                     </item>
                                 </graph_item>
                                 <graph_item>
@@ -1184,7 +1184,7 @@ which has the meaning as:&#13;
                                     <type>0</type>
                                     <item>
                                         <host>ZBX-CISCO-INTERFACES</host>
-                                        <key>ifOutOctets[{#SNMPVALUE}]</key>
+                                        <key>IfHCOutOctets[{#SNMPVALUE}]</key>
                                     </item>
                                 </graph_item>
                             </graph_items>


### PR DESCRIPTION
We had an issue where the 32bit integers were rolling over too quickly (especially on the 10g links), might be better to just grab the 64-bit ones by default.
