### PR TITLE
Modified some templates for icmpping item.

### DIFF
--- a/zbx-templates/zbx-apc/zbx-apc-ups.xml
+++ b/zbx-templates/zbx-apc/zbx-apc-ups.xml
@@ -233,7 +233,7 @@
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
-                    <units>ms</units>
+                    <units/>
                     <delta>0</delta>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -243,7 +243,7 @@
                     <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
+                    <data_type>3</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>

--- a/zbx-templates/zbx-brocade/zbx-brocade-fc-envmon/zbx-brocade-fc-envmon.xml
+++ b/zbx-templates/zbx-brocade/zbx-brocade-fc-envmon/zbx-brocade-fc-envmon.xml
@@ -233,7 +233,7 @@
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
-                    <units>ms</units>
+                    <units/>
                     <delta>0</delta>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -243,7 +243,7 @@
                     <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
+                    <data_type>3</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>

--- a/zbx-templates/zbx-cisco/zbx-cisco-envmon/zbx-cisco-envmon.xml
+++ b/zbx-templates/zbx-cisco/zbx-cisco-envmon/zbx-cisco-envmon.xml
@@ -272,7 +272,7 @@
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
-                    <units>ms</units>
+                    <units/>
                     <delta>0</delta>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -282,7 +282,7 @@
                     <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
+                    <data_type>3</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>

--- a/zbx-templates/zbx-dell-powerconnect/zbx-dell-powerconnect-envmon/zbx-dell-powerconnect-envmon.xml
+++ b/zbx-templates/zbx-dell-powerconnect/zbx-dell-powerconnect-envmon/zbx-dell-powerconnect-envmon.xml
@@ -272,7 +272,7 @@
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
-                    <units>ms</units>
+                    <units/>
                     <delta>0</delta>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -282,7 +282,7 @@
                     <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
+                    <data_type>3</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>

--- a/zbx-templates/zbx-eaton/zbx-powerware-ups.xml
+++ b/zbx-templates/zbx-eaton/zbx-powerware-ups.xml
@@ -490,7 +490,7 @@
                     <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
+                    <data_type>3</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>

--- a/zbx-templates/zbx-fortinet/zbx-fortinet-envmon/zbx-fortinet-envmon.xml
+++ b/zbx-templates/zbx-fortinet/zbx-fortinet-envmon/zbx-fortinet-envmon.xml
@@ -221,19 +221,19 @@
                     <valuemap/>
                 </item>
                 <item>
-                    <name>Device reachability using ICMP</name>
+                    <name>Device packet loss</name>
                     <type>3</type>
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>icmpping</key>
-                    <delay>300</delay>
+                    <key>icmppingloss</key>
+                    <delay>60</delay>
                     <history>7</history>
                     <trends>365</trends>
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
-                    <units>ms</units>
+                    <units>%</units>
                     <delta>0</delta>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -244,6 +244,45 @@
                     <params/>
                     <ipmi_sensor/>
                     <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>Information(s)</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                </item>
+                <item>
+                    <name>Device reachability using ICMP</name>
+                    <type>3</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>icmpping</key>
+                    <delay>60</delay>
+                    <history>7</history>
+                    <trends>365</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>3</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>
@@ -568,6 +607,16 @@
             <url/>
             <status>0</status>
             <priority>1</priority>
+            <description/>
+            <type>0</type>
+            <dependencies/>
+        </trigger>
+        <trigger>
+            <expression>{ZBX-FORTINET-ENVMON:icmpping.avg(600)}&gt;0&amp;{ZBX-FORTINET-ENVMON:icmppingloss.avg(600)}&gt;1</expression>
+            <name>Packet loss detected on {HOST.NAME}</name>
+            <url/>
+            <status>0</status>
+            <priority>3</priority>
             <description/>
             <type>0</type>
             <dependencies/>

--- a/zbx-templates/zbx-infortrend/zbx-ift-sa.xml
+++ b/zbx-templates/zbx-infortrend/zbx-ift-sa.xml
@@ -239,7 +239,7 @@
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
-                    <units>ms</units>
+                    <units/>
                     <delta>0</delta>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -249,7 +249,7 @@
                     <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
+                    <data_type>3</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>

--- a/zbx-templates/zbx-linux/zbx-linux-envmon/zbx-linux-envmon.xml
+++ b/zbx-templates/zbx-linux/zbx-linux-envmon/zbx-linux-envmon.xml
@@ -1032,7 +1032,7 @@
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
-                    <units>ms</units>
+                    <units/>
                     <delta>0</delta>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1042,7 +1042,7 @@
                     <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
+                    <data_type>3</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>

--- a/zbx-templates/zbx-netopia/zbx-netopia-envmon/zbx-netopia-envmon.xml
+++ b/zbx-templates/zbx-netopia/zbx-netopia-envmon/zbx-netopia-envmon.xml
@@ -233,7 +233,7 @@
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
-                    <units>ms</units>
+                    <units/>
                     <delta>0</delta>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -243,7 +243,7 @@
                     <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
+                    <data_type>3</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>

--- a/zbx-templates/zbx-windows/zbx-windows-envmon/zbx-windows-envmon.xml
+++ b/zbx-templates/zbx-windows/zbx-windows-envmon/zbx-windows-envmon.xml
@@ -963,7 +963,7 @@
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
-                    <units>ms</units>
+                    <units/>
                     <delta>0</delta>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -973,7 +973,7 @@
                     <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
+                    <data_type>3</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>


### PR DESCRIPTION
Hi Jean,

icmpping item/value was treated as round-trip time in your templates,
so I modified them as following...
- deleted value unit(ms) and  changed data type to boolean for icmpping item
- added icmppingloss item/trigger to zbx-fortinet-envmon same as zbx-cisco-envmon.

I think icmppingsec item should be used if getting icmp response time.

Would you merge these changes?

Regards,
