### PR TITLE
Fix trigger name for upsBasicBatteryStatus monitor.

### DIFF
--- a/zbx-templates/zbx-apc/zbx-apc-ups.xml
+++ b/zbx-templates/zbx-apc/zbx-apc-ups.xml
@@ -910,8 +910,8 @@
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{ZBX-APC-UPS:upsBasicBatteryStatus.last(0)}#2</expression>
-            <name>Loss of input power</name>
+            <expression>{ZBX-APC-UPS:upsBasicBatteryStatus.last(0)}=3</expression>
+            <name>The battery power is too low to support the load; if power fails, the UPS will be shut down immediately</name>
             <url/>
             <status>0</status>
             <priority>5</priority>


### PR DESCRIPTION
According to http://support.ipmonitor.com/mibs/POWERNET-MIB/item.aspx?id=upsBasicBatteryStatus

The status of the UPS batteries.  A batteryLow(3) value indicates the UPS will be unable to sustain the current load, and its services will be lost if power is not restored.  The amount of run time in reserve at the time of low battery can be configured by the upsAdvConfigLowBatteryRunTime.

This changes the trigger name to match that of the APC event.