### PR TITLE
Update zabbix_vbr_job.ps1

### DIFF
--- a/zbx-templates/zbx-veeam/zabbix_vbr_job.ps1
+++ b/zbx-templates/zbx-veeam/zabbix_vbr_job.ps1
@@ -94,6 +94,14 @@ switch ($ITEM) {
 	return "0"
     }
   }
+    "24hJobCount" {
+  $query = Get-VBRBackupSession | where { $_.EndTime -gt ((Get-Date).AddDays(-1)) } | Measure
+  if ($query) {
+    [string]$query.Count
+    } else {
+    return "0"
+    }
+  }
   default {
       Write-Host "-- ERROR -- : Need an option to work !"
   }


### PR DESCRIPTION
Hello

Please review proposed changes to monitor 'No Veeam jobs have run in the past 24h'.
We encountered one problem where our Veeam license has expired and the jobs stopped processing. Although we were monitoring our server with your script, we were unaware of this critical event. This is the reason why we are amending the '24hJobCount' - Addition made by Sean Nienaber

Our little contribution, please share/include this changes if you find them useful.

Keep up the good work.
Thank You.
