### PR TITLE
Add Frame Check Sequence counter for Dell PowerConnect/N-series switches

### DIFF
--- a/zbx-templates/zbx-dell-powerconnect/zbx-dell-powerconnect-interfaces/zbx-dell-powerconnect-interfaces.xml
+++ b/zbx-templates/zbx-dell-powerconnect/zbx-dell-powerconnect-interfaces/zbx-dell-powerconnect-interfaces.xml
@@ -169,6 +169,45 @@
                             <valuemap/>
                         </item_prototype>
                         <item_prototype>
+                            <name>Frame Check Sequence errors on interface $1</name>
+                            <type>4</type>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                            <multiplier>0</multiplier>
+                            <snmp_oid>.1.3.6.1.2.1.10.7.2.1.3.{#SNMPINDEX}</snmp_oid>
+                            <key>ifFCSErrors[{#SNMPVALUE}]</key>
+                            <delay>300</delay>
+                            <history>1</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units>errors/s</units>
+                            <delta>1</delta>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>Interface(s)</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                        </item_prototype>
+                        <item_prototype>
                             <name>Inbound errors on interface $1</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>


### PR DESCRIPTION
We've found it very handy to specifically count Frame Check Sequence errors on interfaces.  They generally mean the network cable needs re-seating or replacing and have a high signal/noise ratio in terms of indicating an actual problem.

This has been tested on several Dell N4064 switches running 6.1.x, 6.2.x, and 6.3.x firmware over several months.
