### PR TITLE
RFC-IGNORANT.DE discontinued

### DIFF
--- a/zbx-scripts/rbl.check/README.md
+++ b/zbx-scripts/rbl.check/README.md
@@ -77,7 +77,6 @@ Use `rbl.check` like an **External Check** item in Zabbix.  So, when creating an
   SURRIEL             =>     psbl.surriel.com
   SPAMLAB             =>     rbl.spamlab.com
   BOGONS_CYMRU        =>     bogons.cymru.com
-  RFC-IGNORANT        =>     dsn.bl.rfc-ignorant.de
 
 Version
 -------

--- a/zbx-scripts/rbl.check/rbl.check
+++ b/zbx-scripts/rbl.check/rbl.check
@@ -45,7 +45,6 @@ Supported RBLs are :
   SURRIEL             =>     psbl.surriel.com
   SPAMLAB             =>     rbl.spamlab.com
   BOGONS_CYMRU        =>     bogons.cymru.com
-  RFC-IGNORANT        =>     dsn.bl.rfc-ignorant.de
 
 USAGE:
   as a script:          rbl.check [options]
@@ -118,7 +117,6 @@ c.add_dnsbl("CDL_ANTISPAM_ORG_CN","cdl.anti-spam.org.cn",'ip',{"0"=>"OK","127.0.
 c.add_dnsbl("SURRIEL","psbl.surriel.com",'ip',{"0"=>"OK","127.0.0.2"=>"Blacklisted"})
 c.add_dnsbl("SPAMLAB","rbl.spamlab.com",'ip',{"0"=>"OK","127.0.0.2"=>"Blacklisted"})
 c.add_dnsbl("BOGONS_CYMRU","bogons.cymru.com",'ip',{"0"=>"OK","127.0.0.2"=>"Blacklisted"})
-c.add_dnsbl("RFC-IGNORANT","dsn.bl.rfc-ignorant.de",'ip',{"0"=>"OK","127.0.0.2"=>"Blacklisted"})
 
 # Create @RBLs list
 @rbls = c.dnsbls

--- a/zbx-templates/zbx-rblcheck/README.md
+++ b/zbx-templates/zbx-rblcheck/README.md
@@ -40,7 +40,6 @@ Actually supported RBLs are :
  * SURRIEL             =>     psbl.surriel.com
  * SPAMLAB             =>     rbl.spamlab.com
  * BOGONS_CYMRU        =>     bogons.cymru.com
- * RFC-IGNORANT        =>     dsn.bl.rfc-ignorant.de
 
 Items
 -----
@@ -87,7 +86,6 @@ Triggers
   * **[HIGH]** => Host is blacklisted on SURRIEL
   * **[HIGH]** => Host is blacklisted on SPAMLAB
   * **[HIGH]** => Host is blacklisted on BOGONS_CYMRU
-  * **[HIGH]** => Host is blacklisted on RFC-IGNORANT
 
 Installation
 ------------

--- a/zbx-templates/zbx-rblcheck/zbx-rblcheck.xml
+++ b/zbx-templates/zbx-rblcheck/zbx-rblcheck.xml
@@ -260,16 +260,6 @@
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{ZBX-RBLCHECK:rbl.check[&quot;-q&quot;,&quot;{HOST.IP}&quot;].regexp(&quot;RFC-IGNORANT&quot;)}=1</expression>
-            <name>{HOST.NAME} is blacklisted on RFC-IGNORANT</name>
-            <url/>
-            <status>0</status>
-            <priority>4</priority>
-            <description>Lookup URL:</description>
-            <type>0</type>
-            <dependencies/>
-        </trigger>
-        <trigger>
             <expression>{ZBX-RBLCHECK:rbl.check[&quot;-q&quot;,&quot;{HOST.IP}&quot;].regexp(&quot;RHSBL&quot;)}=1</expression>
             <name>{HOST.NAME} is blacklisted on RHSBL</name>
             <url/>


### PR DESCRIPTION
Removed RFC-IGNORANT.DE from scripts (rbl.check) and templates (zbx-rblcheck) due to server shutdown.